### PR TITLE
[fix] URL in the Who-We-Are section

### DIFF
--- a/who-we-are/index.html
+++ b/who-we-are/index.html
@@ -158,7 +158,7 @@
 
 
 <div class="wp-block-buttons">
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" href="https://dpgwebsite-staging.herokuapp.com/registry/">Visit the DPG Registry</a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" href="https://digitalpublicgoods.net/registry/">Visit the DPG Registry</a></div>
 </div>
 </div>
 
@@ -174,7 +174,7 @@
 
 
 <div class="wp-block-buttons">
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" href="https://dpgwebsite-staging.herokuapp.com/who-we-are/">Pathfinder Countries</a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" href="https://digitalpublicgoods.net/who-we-are/">Pathfinder Countries</a></div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
**Problem**:
On the main website, https://digitalpublicgoods.net/who-we-are/, two links in the "Our Approach" seems dead, and built for dev.

**Solution**:
Correct the two links.

**Status**:
Not tested -> Minor changes. 
Waiting for review.

---
PS : Not sure it's a good contribution, but I tried :-)